### PR TITLE
Add support for the Document PiP API

### DIFF
--- a/index.css
+++ b/index.css
@@ -481,6 +481,13 @@ video.pipactive {
 	display: block;
 }
 
+.pip::after {
+	content: "Picture in Picture Mode Active";
+	display: block;
+	position: absolute;
+	top: 50%;
+}
+
 #firstload {
 	display: none;
 	width: 100vw;


### PR DESCRIPTION
This PR adds support for the [Document PiP API](https://github.com/WICG/document-picture-in-picture). Like that, the timer can be paused right from the PiP window. On supporting browsers, this is more resource-friendly compared to the `canvas` to `video` hack that the current PiP mode has to use. 

![Screenshot 2023-01-17 at 14 14 29](https://user-images.githubusercontent.com/145676/212908459-ee1dd409-e0f6-48a0-8993-0dcf5e5fe2c2.png)
