### PR TITLE
Resolve copyStyleSheets option removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1529,6 +1529,26 @@ if ('documentPictureInPicture' in window) {
 
 		pipWindow = await documentPictureInPicture.requestWindow(pipOptions);
 
+		// Copy style sheets over from the initial document
+		// so that the player looks the same.
+		[...document.styleSheets].forEach((styleSheet) => {
+			try {
+				const cssRules = [...styleSheet.cssRules].map((rule) => rule.cssText).join('');
+				const style = document.createElement('style');
+
+				style.textContent = cssRules;
+				pipWindow.document.head.appendChild(style);
+			} catch (e) {
+				const link = document.createElement('link');
+
+				link.rel = 'stylesheet';
+				link.type = styleSheet.type;
+				link.media = styleSheet.media;
+				link.href = styleSheet.href;
+				pipWindow.document.head.appendChild(link);
+			}
+		});
+
 		// Add timer to the PiP window.
 		pipWindow.document.body.append(timer);
 


### PR DESCRIPTION
https://developer.chrome.com/docs/web-platform/document-picture-in-picture/#copy-style-sheets-to-the-picture-in-picture-window

The copyStyleSheets option was supported in a previous version of the specification. It is not the case anymore.

https://github.com/WICG/document-picture-in-picture/pull/79